### PR TITLE
Planning: backup the google table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 !header.tex
 .~lock*
 *.tar.gz
+/local_backups/

--- a/R/backup_planning.R
+++ b/R/backup_planning.R
@@ -33,14 +33,12 @@ write_local_backup <- function(ss = gs_id(), verbose = TRUE, filetype = c('rds',
   # check that the loaded table is of the right type and dimension
   if (!inherits(planning_table, "data.frame")) {
     # table loading can be unsuccessful.
-    warning("backup unsuccessful: no data frame loaded.")
-    return(invisible(NULL))
+    stop("backup unsuccessful: no data frame loaded.")
   }
 
   if ((nrow(planning_table) == 0) || (ncol(planning_table) == 0)) {
   # if a table was loaded, back it up.
-    warning("Planning table is empty (zero dimension). Did the data load correctly? No backup stored.")
-    return(invisible(NULL))
+    stop("Planning table is empty (zero dimension). Did the data load correctly? No backup stored.")
   }
 
   # choose a meaningful storage path

--- a/R/backup_planning.R
+++ b/R/backup_planning.R
@@ -6,19 +6,6 @@
 source("R/functions.R")
 library(googlesheets4)
 
-#' Read the Planning_v2 sheet in the planning googlesheet.
-#' @details see R/functions.R/get_planning_long()
-#' @param ss The id of the planning googlesheet
-get_planning_raw <- function(ss = gs_id()) {
-  # read the planning data
-  read_sheet(
-    ss,
-    sheet = "Planning_v2",
-    col_types = "ccccclllilccccccdddddddddddccdddddddddddcc",
-    .name_repair = "minimal"
-    )
-}
-
 
 #' Store a local backup of the google planning table.
 #' @details
@@ -38,7 +25,7 @@ write_local_backup <- function(ss = gs_id(), verbose = TRUE, filetype = c('rds',
       # create it... if the user confirms
       dir.create(here::here("local_backups"), showWarnings = FALSE)
     } else {
-      print("No backup stored.")
+      message("No backup stored.")
       return(NA)
     }
   }
@@ -46,7 +33,7 @@ write_local_backup <- function(ss = gs_id(), verbose = TRUE, filetype = c('rds',
   # backup the table
   if (missing(planning_table)) {
     # table loading can be unsuccesful.
-    print("backup unsuccesful: no table loaded.")
+    message("backup unsuccesful: no table loaded.")
   } else {
     # if a table was loaded, back it up.
 
@@ -65,7 +52,7 @@ write_local_backup <- function(ss = gs_id(), verbose = TRUE, filetype = c('rds',
 
     # optionally report execution
     if (verbose) {
-      print(paste0('planning sheet backed up here: ', file_path_backup))
+      message(paste0('planning sheet backed up here: ', file_path_backup))
     }
 
   } # table backup

--- a/R/backup_planning.R
+++ b/R/backup_planning.R
@@ -30,31 +30,34 @@ write_local_backup <- function(ss = gs_id(), verbose = TRUE, filetype = c('rds',
     }
   }
 
-  # backup the table
-  if (missing(planning_table)) {
-    # table loading can be unsuccesful.
-    warning("backup unsuccesful: no table loaded.")
-  } else {
-    # if a table was loaded, back it up.
+  # check that the loaded table is of the right type and dimension
+  if (!inherits(planning_table, "data.frame")) {
+    # table loading can be unsuccessful.
+    warning("backup unsuccessful: no data frame loaded.")
+    return(invisible(NULL))
+  }
 
-    # ... in a smart (?) location
-    extension <- match.arg(filetype)
+  if ((nrow(planning_table) == 0) || (ncol(planning_table) == 0)) {
+  # if a table was loaded, back it up.
+    warning("Planning table is empty (zero dimension). Did the data load correctly? No backup stored.")
+    return(invisible(NULL))
+  }
 
-    # choose a meaningful storage path
-    file_name <- paste0(format(Sys.time(), "%Y%m%d_planning_googlesheet"),
-                        ".", extension)
-    file_path_backup <- here::here("local_backups", file_name)
+  # choose a meaningful storage path
+  extension <- match.arg(filetype)
+  file_name <- paste0(format(Sys.time(), "%Y%m%d_planning_googlesheet"),
+                      ".", extension)
+  file_path_backup <- here::here("local_backups", file_name)
 
-    # write the backup
-    switch(extension,
-           rds = saveRDS(planning_table, file_path_backup),
-           csv = readr::write_csv(planning_table, file_path_backup)
-           )
+  # write the backup
+  switch(extension,
+         rds = saveRDS(planning_table, file_path_backup),
+         csv = readr::write_csv(planning_table, file_path_backup)
+         )
 
-    # optionally report execution
-    if (verbose) {
-      message(paste0('planning sheet backed up here: ', file_path_backup))
-    }
+  # optionally report execution
+  if (verbose) {
+    message(paste0('planning sheet backed up here: ', file_path_backup))
+  }
 
-  } # table backup
 } # local_backup

--- a/R/backup_planning.R
+++ b/R/backup_planning.R
@@ -1,0 +1,73 @@
+# This file is supposed to be run to create timed backups of the MNM planning google sheet.
+# The table is dumped to a binary file.
+# Pure backup for now; we will take care of restoration later.
+
+
+source("R/functions.R")
+library(googlesheets4)
+
+#' read the Planning_v2 sheet in the planning googlesheet.
+#' @details see R/functions.R/get_planning_long()
+#' @param ss The id of the planning googlesheet
+get_planning_raw <- function(ss = gs_id()) {
+  # read the planning data
+  read_sheet(
+    ss,
+    sheet = "Planning_v2",
+    col_types = "ccccclllilccccccdddddddddddccdddddddddddcc",
+    .name_repair = "minimal"
+    )
+}
+
+
+#' Procedure to store a local backup of the google planning table.
+#' @details
+#' This will take a table and save it to disk,
+#' either as `rds` or as `csv`.
+#' @param ss a google sheet ID.
+#' @param filetype rds (binary) or csv (text).
+#' @param verbose whether or not output shall be printed.
+#' @examples local_backup(verbose = TRUE, filetype = 'rds')
+local_backup <- function(ss = gs_id(), verbose = TRUE, filetype = c('rds', 'csv')) {
+
+  # query the planning table
+  planning_table <- get_planning_raw(ss)
+
+  # check if the directory exists
+  if (!file.exists(here::here("local_backups"))) {
+    if (utils::askYesNo("Shall we create a local backups folder?")) {
+      # create it... if the user confirms
+      dir.create(here::here("local_backups"), showWarnings = FALSE)
+    } else {
+      print("No backup stored.")
+      return(NA)
+    }
+  }
+
+  # backup the table
+  if (missing(planning_table)) {
+    # table loading can be unsuccesful.
+    print("backup unsuccesful: no table loaded.")
+  } else {
+    # if a table was loaded, back it up.
+
+    # ... in a smart (?) location
+    extension <- match.arg(filetype)
+
+    # choose a meaningful storage path
+    file_name <- paste0(format(Sys.time(), "%Y%m%d_planning_googlesheet"), ".", extension)
+    file_path_backup <- here::here("local_backups", file_name)
+
+    # write the backup
+    switch(extension,
+           rds = saveRDS(planning_table, file_path_backup),
+           csv = write.csv(planning_table, file_path_backup)
+           )
+
+    # optionally report execution
+    if (verbose) {
+      print(paste0('planning sheet backed up here: ', file_path_backup))
+    }
+
+  } # table backup
+} # local_backup

--- a/R/backup_planning.R
+++ b/R/backup_planning.R
@@ -6,7 +6,7 @@
 source("R/functions.R")
 library(googlesheets4)
 
-#' read the Planning_v2 sheet in the planning googlesheet.
+#' Read the Planning_v2 sheet in the planning googlesheet.
 #' @details see R/functions.R/get_planning_long()
 #' @param ss The id of the planning googlesheet
 get_planning_raw <- function(ss = gs_id()) {
@@ -20,15 +20,14 @@ get_planning_raw <- function(ss = gs_id()) {
 }
 
 
-#' Procedure to store a local backup of the google planning table.
+#' Store a local backup of the google planning table.
 #' @details
-#' This will take a table and save it to disk,
-#' either as `rds` or as `csv`.
+#' Take the planning table and save it to disk, either as `rds` or as `csv`.
 #' @param ss a google sheet ID.
 #' @param filetype rds (binary) or csv (text).
 #' @param verbose whether or not output shall be printed.
-#' @examples local_backup(verbose = TRUE, filetype = 'rds')
-local_backup <- function(ss = gs_id(), verbose = TRUE, filetype = c('rds', 'csv')) {
+#' @examples write_local_backup(verbose = TRUE, filetype = 'rds')
+write_local_backup <- function(ss = gs_id(), verbose = TRUE, filetype = c('rds', 'csv')) {
 
   # query the planning table
   planning_table <- get_planning_raw(ss)

--- a/R/backup_planning.R
+++ b/R/backup_planning.R
@@ -26,14 +26,14 @@ write_local_backup <- function(ss = gs_id(), verbose = TRUE, filetype = c('rds',
       dir.create(here::here("local_backups"), showWarnings = FALSE)
     } else {
       message("No backup stored.")
-      return(NA)
+      return(invisible(NULL))
     }
   }
 
   # backup the table
   if (missing(planning_table)) {
     # table loading can be unsuccesful.
-    message("backup unsuccesful: no table loaded.")
+    warning("backup unsuccesful: no table loaded.")
   } else {
     # if a table was loaded, back it up.
 
@@ -41,13 +41,14 @@ write_local_backup <- function(ss = gs_id(), verbose = TRUE, filetype = c('rds',
     extension <- match.arg(filetype)
 
     # choose a meaningful storage path
-    file_name <- paste0(format(Sys.time(), "%Y%m%d_planning_googlesheet"), ".", extension)
+    file_name <- paste0(format(Sys.time(), "%Y%m%d_planning_googlesheet"),
+                        ".", extension)
     file_path_backup <- here::here("local_backups", file_name)
 
     # write the backup
     switch(extension,
            rds = saveRDS(planning_table, file_path_backup),
-           csv = write.csv(planning_table, file_path_backup)
+           csv = readr::write_csv(planning_table, file_path_backup)
            )
 
     # optionally report execution

--- a/R/functions.R
+++ b/R/functions.R
@@ -24,7 +24,11 @@ sanity_checks <- function (.data) {
 }
 
 #' Read the Planning_v2 sheet in the planning googlesheet.
+#'
 #' @details see R/functions.R/get_planning_long()
+#'
+#' @keywords internal
+#'
 #' @param ss The id of the planning googlesheet
 get_planning_raw <- function(ss = gs_id()) {
   # read the planning data

--- a/R/functions.R
+++ b/R/functions.R
@@ -23,6 +23,20 @@ sanity_checks <- function (.data) {
   return(.data)
 }
 
+#' Read the Planning_v2 sheet in the planning googlesheet.
+#' @details see R/functions.R/get_planning_long()
+#' @param ss The id of the planning googlesheet
+get_planning_raw <- function(ss = gs_id()) {
+  # read the planning data
+  read_sheet(
+    ss,
+    sheet = "Planning_v2",
+    col_types = "ccccclllilccccccdddddddddddccdddddddddddcc",
+    .name_repair = "minimal"
+    )
+}
+
+
 
 #' Generate a long-format planning table from the Planning_v2 sheet in the
 #' planning googlesheet.
@@ -38,12 +52,7 @@ sanity_checks <- function (.data) {
 #' @param ss The id of the planning googlesheet
 get_planning_long <- function(ss = gs_id()) {
   # read the planning data
-  read_sheet(
-    ss,
-    sheet = "Planning_v2",
-    col_types = "ccccclllilccccccdddddddddddccdddddddddddcc",
-    .name_repair = "minimal"
-    ) |>
+  get_planning_raw(ss = ss) |>
     sanity_checks() |>
     # clean planning data and turn it into long format
     clean_names() |>


### PR DESCRIPTION
An initial shot at local backups of our google planning sheet.
Note that this currently only works on the main table; other tables can be added later.

Purpose is to run this on demand or with a cronjob.