### PR TITLE
Planning: allow pretending the current date

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -3,6 +3,14 @@
 #' Return id of the planning googlesheet
 gs_id <- function() "1HLtyGK_csi5W_v7XChxgTuVjS-RKXqc0Jxos1RBqpwk"
 
+#' Give the current (pretended) date
+local_today <- function() {
+  if (exists("today_pretend") && !is.null(today_pretend)) {
+    ymd(today_pretend)
+  } else {
+    today()
+  }
+}
 
 #' Sanity checks for the google sheet table "planning_v2".
 #'
@@ -127,8 +135,8 @@ get_planning_long <- function(ss = gs_id()) {
       started = !is.na(gestart),
       finished = !is.na(afgerond),
       # first & last day of current month
-      first_day_currentmonth = floor_date(today(), unit = "month"),
-      last_day_currentmonth = ceiling_date(today(), unit = "month") - days(1),
+      first_day_currentmonth = floor_date(local_today(), unit = "month"),
+      last_day_currentmonth = ceiling_date(local_today(), unit = "month") - days(1),
       # which start date to take in calculating currently applicable interval?
       begin = case_when(
         started ~ gestart,
@@ -139,7 +147,7 @@ get_planning_long <- function(ss = gs_id()) {
       end = ifelse(finished, afgerond, deadline) |>
         as.Date(),
       # is the task overdue?
-      overdue = !finished & today() > end,
+      overdue = !finished & local_today() > end,
       # number of months of the interval
       nr_months = case_when(
         started & overdue ~ as.period(last_day_currentmonth - begin),
@@ -310,7 +318,7 @@ update_person_sheets <- function(planning_long,
       values_from = nr_days,
       values_fill = 0
     ) |>
-    filter(doen_we, !finished, floor_date(today(), unit = "month") <= date) |>
+    filter(doen_we, !finished, floor_date(local_today(), unit = "month") <= date) |>
     nest(data = -person) |>
     (function(x) {
       walk2(x$person, x$data, function(name, df) {

--- a/R/planning_helper.R
+++ b/R/planning_helper.R
@@ -18,7 +18,7 @@ library(lubridate)
 library(purrr)
 source("R/functions.R")
 
-#' Optionally change below max_year value; it's used to limit processed results
+# Optionally change below max_year value; it's used to limit processed results
 max_y <- function() 2025
 
 # Get planning table as long-table format

--- a/R/planning_helper.R
+++ b/R/planning_helper.R
@@ -21,6 +21,12 @@ source("R/functions.R")
 # Optionally change below max_year value; it's used to limit processed results
 max_y <- function() 2025
 
+# Optionally pretend another 'current date'. Provide as ymd string.
+# Example:
+# today_pretend <- "2025-02-01"
+# NULL or missing 'today_pretend' will lead to using the actual current date.
+today_pretend <- NULL
+
 # Get planning table as long-table format
 pl_long <- get_planning_long()
 

--- a/n2khab-monitoring.Rproj
+++ b/n2khab-monitoring.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 7111d5d2-e33f-4df7-b6a1-81c4a66b7f84
 
 RestoreWorkspace: Default
 SaveWorkspace: Default


### PR DESCRIPTION
This can be useful when you're at the end of a month and want to look forward. When setting `today_pretend` in the next month, then the `get_planning_long()` and `update_person_sheets()` functions will handle the current month as a past month.

I've tested it and it seems to work.